### PR TITLE
chore(bs4): add peer dependence `popper.js` for `bs4`

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4370,6 +4370,11 @@
         "pinkie": "2.0.4"
       }
     },
+    "popper.js": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
+      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "dependencies": {
     "bootstrap": "^4.0.0",
-    "jquery": "^3.3.1"
+    "jquery": "^3.3.1",
+    "popper.js": "^1.12.9"
   },
   "devDependencies": {
     "@types/node": "^9.3.0",


### PR DESCRIPTION
```shell
bootstrap@4.0.0 requires a peer of popper.js@^1.12.9 but none is installed. You must install peer dependencies yourself.
```